### PR TITLE
Support ActionMailer lazy-loading

### DIFF
--- a/lib/premailer/rails/railtie.rb
+++ b/lib/premailer/rails/railtie.rb
@@ -1,7 +1,7 @@
 class Premailer
   module Rails
     class Railtie < ::Rails::Railtie
-      config.after_initialize do
+      ActiveSupport.on_load(:action_mailer) do
         ::Premailer::Rails.register_interceptors
       end
     end


### PR DESCRIPTION
Allow ActionMailer to be lazy-loaded. Currently premailer-rails triggers the loading of ActionMailer during the bootstrapping, but it can be postponed until the mailer is actually used.

ActiveSupport is not a direct dependency of ActionMailer, but it has been required via [indirect dependencies](https://github.com/rails/rails/pull/37335) since [version 3](https://github.com/rails/rails/blob/v3.0.0/actionmailer/lib/action_mailer/railtie.rb#L20) (the earliest version supported by premailer-rails).

Previously proposed here: https://github.com/fphilipe/premailer-rails/pull/260